### PR TITLE
Load custom-file

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -67,6 +67,7 @@
 
 ;; Write customizations to ~/.emacs.d/custom.el instead of this file.
 (setq custom-file "~/.emacs.d/custom.el")
+(load custom-file t t)
 
 ;; Install packages.
 (setq package-list '(markdown-mode paredit rainbow-delimiters))

--- a/.emacs
+++ b/.emacs
@@ -67,7 +67,7 @@
 
 ;; Write customizations to ~/.emacs.d/custom.el instead of this file.
 (setq custom-file "~/.emacs.d/custom.el")
-(load custom-file t t)
+(load custom-file 'noerror)
 
 ;; Install packages.
 (setq package-list '(markdown-mode paredit rainbow-delimiters))


### PR DESCRIPTION
Emacs won't load any `custom-file` after the initialization. Instead, we need to `load` the file manually. That's mentioned in `custom-file`'s documentation:

> [...] it is simpler to write something like the following in your init file:
> ```lisp
> (setq custom-file "~/.emacs-custom.el")
> (load custom-file)
> ```
> [...] You also have to put something like `(load "CUSTOM-FILE")` in your init file, where `CUSTOM-FILE` is the actual name of the file.

Since `emfy`'s `.emacs` acts as a starting point, I guess we don't want to get an error if there was no customization yet, that's why the commit has `NOERROR` set to `t`. `NOMESSAGE` is set to `t` too to reduce the amount of noise during initialization.