### PR TITLE
Starting emacs using nohup for POSIX compliance

### DIFF
--- a/em
+++ b/em
@@ -3,11 +3,11 @@
 if [ "$#" -eq 0 ]
 then
     echo "Starting new Emacs process ..." >&2
-    emacs & disown
+    nohup emacs &
 elif emacsclient -n "$@" 2> /dev/null
 then
     echo "Opened $@ in Emacs server" >&2
 else
     echo "Opening $@ in a new Emacs process ..." >&2
-    emacs "$@" & disown
+    nohup emacs "$@" &
 fi


### PR DESCRIPTION
nohup seems to be working when using in the "em" script and does not
close the emacs app.